### PR TITLE
DRBD hostname clarification

### DIFF
--- a/ig/config_drbd.dita
+++ b/ig/config_drbd.dita
@@ -144,7 +144,7 @@ drbdadm connect r0</codeblock>
         		<cmd>Set up the DRBD block device on the primary Walrus:</cmd>
         		<info>
         			<codeblock>drbdsetup /dev/drbd1 syncer -r 110M
-drbdadm --overwrite-data-of-peer primary r0</codeblock>
+drbdadm -- --overwrite-data-of-peer primary r0</codeblock>
 
         		</info>
         	</step>


### PR DESCRIPTION
Since this has tripped users up, adding a quick couple of words to state the hostname must be the same as the output of uname -n cmd ...73
