### PR TITLE
Reorder DRBD steps slightly to avoid HA role switch

### DIFF
--- a/ig/config_drbd.dita
+++ b/ig/config_drbd.dita
@@ -121,14 +121,16 @@ include "/etc/eucalyptus/drbd.conf";</codeblock>
         		</info>
         	</step>
         	<step>
-        		<cmd>Restart Walrus.</cmd>
+        		<cmd>Copy the <filepath>/etc/drbd.conf</filepath>, the
+        			<filepath>/etc/eucalyptus/drbd.conf</filepath>, and the <filepath>/etc/eucalyptus/eucalyptus.conf</filepath> files to the secondary Walrus server.</cmd>
+        	</step>
+        	<step>
+        		<cmd>Restart Walrus, first on the primary, and then on the secondary. Restarting the primary Walrus
+                             will trigger an HA failover to the secondary, and restarting the secondary will fail back, preparing
+                             the entire system for the next steps.</cmd>
         		<info>
         			<codeblock>service eucalyptus-cloud restart</codeblock>
         		</info>
-        	</step>
-        	<step>
-        		<cmd>Copy the <filepath>/etc/drbd.conf</filepath>, the
-        			<filepath>/etc/eucalyptus/drbd.conf</filepath>, and the <filepath>/etc/eucalyptus/eucalyptus.conf</filepath> files to the secondary Walrus server.</cmd>
         	</step>
         	<step>
         		<cmd>On the primary Walrus, associate the DRBD block device (<filepath>/dev/drbd1</filepath>) with the disk


### PR DESCRIPTION
When you're following the DRBD config docs as written, the primary/secondary Walruses will switch HA roles halfway through, and that means all of the subsequent steps to be performed on the "primary" walrus now need to be done on the other machine. This is easy to get wrong. It's also necessary to restart the secondary walrus anyway, so by adding that second reset as an explicit step, we trigger the first failover by restarting the initial primary walrus, then we ensure a fail-back by restarting the secondary walrus which puts the original primary back, making the instructions easier to follow.
