### PR TITLE
Sort euca-* commands in the CLI guide ToC

### DIFF
--- a/content/en_us/cli.ditamap
+++ b/content/en_us/cli.ditamap
@@ -22,8 +22,6 @@
 		<topicref href="shared/source_eucarc.dita" type="task"/>
 	</topicref>
 	<topicref href="cli/euca.dita">
-		<topicref href="cli/euca-create-group.dita" type="reference"/>
-		<topicref href="cli/euca-create-keypair.dita" type="reference"/>
 		<topicref href="cli/euca-allocate-address.dita" type="reference"/>
 		<topicref href="cli/euca-associate-address.dita" type="reference"/>
 		<topicref href="cli/euca-attach-volume.dita" type="reference"/>
@@ -32,6 +30,8 @@
 		<topicref href="cli/euca-bundle-instance.dita" type="reference"/>
 		<topicref href="cli/euca-bundle-vol.dita" type="reference"/>
 		<topicref href="cli/euca-cancel-bundle-task.dita" type="reference"/>
+		<topicref href="cli/euca-create-group.dita" type="reference"/>
+		<topicref href="cli/euca-create-keypair.dita" type="reference"/>
 		<topicref href="cli/euca-create-snapshot.dita" type="reference"/>
 		<topicref href="cli/euca-create-volume.dita" type="reference"/>
 		<topicref href="cli/euca-delete-bundle.dita" type="reference"/>


### PR DESCRIPTION
euca-create-group and euca-create-keypair appear at the top of the CLI guide's table of contents, which isn't the right place if we're trying to keep the list sorted.  This commit re-sorts the list.
