### PR TITLE
Toast "yum -y"

### DIFF
--- a/content/en_us/ag/installing_dw.dita
+++ b/content/en_us/ag/installing_dw.dita
@@ -12,7 +12,7 @@
             <step>
             	<cmd>Configure the Eucalyptus package repository on the Data Warehouse host:</cmd>
             	<info>
-					<codeblock>yum --nogpgcheck install -y
+					<codeblock>yum --nogpgcheck install
 http://downloads.eucalyptus.com/software/eucalyptus/3.2/centos/6/x86_64/
 eucalyptus-release-3.2.noarch.rpm</codeblock>
             	</info>

--- a/content/en_us/ig/installing_euca_centos6.dita
+++ b/content/en_us/ig/installing_euca_centos6.dita
@@ -14,27 +14,27 @@
 				<cmd>Configure the Eucalyptus package repository on each host that will run a
 					Eucalyptus component:</cmd>
 				<info>
-					<codeblock>yum --nogpgcheck install -y http://downloads.eucalyptus.com/software/eucalyptus/3.2/centos/6/x86_64/eucalyptus-release-3.2.noarch.rpm</codeblock>
+					<codeblock>yum --nogpgcheck install http://downloads.eucalyptus.com/software/eucalyptus/3.2/centos/6/x86_64/eucalyptus-release-3.2.noarch.rpm</codeblock>
 				</info>
 			</step>
 			<step>
 				<cmd>Configure the Euca2ools package repository on each host that will run a
 					Eucalyptus component or Euca2ools:</cmd>
 				<info>
-					<codeblock>yum --nogpgcheck install -y http://downloads.eucalyptus.com/software/euca2ools/2.1/centos/6/x86_64/euca2ools-release-2.1.noarch.rpm</codeblock>
+					<codeblock>yum --nogpgcheck install http://downloads.eucalyptus.com/software/euca2ools/2.1/centos/6/x86_64/euca2ools-release-2.1.noarch.rpm</codeblock>
 				</info>
 			</step>
 			<step>
 				<cmd> Configure the EPEL package repository on each host that will run a Eucalyptus
 					component or Euca2ools: </cmd>
 				<info>
-					<codeblock>yum --nogpgcheck install -y http://downloads.eucalyptus.com/software/eucalyptus/3.2/centos/6/x86_64/epel-release-6.noarch.rpm</codeblock>
+					<codeblock>yum --nogpgcheck install http://downloads.eucalyptus.com/software/eucalyptus/3.2/centos/6/x86_64/epel-release-6.noarch.rpm</codeblock>
 				</info>
 			</step>
 			<step>
 				<cmd>Configure the ELRepo repository on each host that will run Walrus: </cmd>
 				<info>
-					<codeblock>yum --nogpgcheck install -y http://downloads.eucalyptus.com/software/eucalyptus/3.2/centos/6/x86_64/elrepo-release-6.noarch.rpm</codeblock>
+					<codeblock>yum --nogpgcheck install http://downloads.eucalyptus.com/software/eucalyptus/3.2/centos/6/x86_64/elrepo-release-6.noarch.rpm</codeblock>
 				</info>
 			</step>
 			<step props="subscribe">
@@ -44,7 +44,7 @@
 				<cmd>Install the Eucalyptus subscription package on each host that will run a
 					Eucalyptus component:</cmd>
 				<info>
-					<codeblock>yum --nogpgcheck install -y eucalyptus-enterprise-release-3.1*.noarch.rpm</codeblock>
+					<codeblock>yum --nogpgcheck install eucalyptus-enterprise-release-3.1*.noarch.rpm</codeblock>
 				</info>
 			</step>
 			<step>

--- a/content/en_us/ig/installing_euca_nightlies_centos5.dita
+++ b/content/en_us/ig/installing_euca_nightlies_centos5.dita
@@ -14,7 +14,7 @@
     	<step>
     			<cmd>On all servers, run the following commands:</cmd>
     			<info>
-    				<codeblock>yum --nogpg install -y http://downloads.eucalyptus.com/
+    				<codeblock>yum --nogpg install http://downloads.eucalyptus.com/
 software/eucalyptus/nightly/3.1/centos/5/x86_64/eucalyptus-release-nightly-3.1.noarch.rpm</codeblock>
     			</info>
     		</step>
@@ -22,7 +22,7 @@ software/eucalyptus/nightly/3.1/centos/5/x86_64/eucalyptus-release-nightly-3.1.n
                         <cmd>On all systems that will run either Eucalyptus or Euca2ools, run the following
                                 commands:</cmd> 
                         <info>
-                                <codeblock>yum install -y http://downloads.eucalyptus.com/software/
+                                <codeblock>yum install http://downloads.eucalyptus.com/software/
 euca2ools/nightly/2.1/centos/5/x86_64/euca2ools-release-2.1.noarch.rpm</codeblock>
                         </info>
                 </step>

--- a/content/en_us/ig/installing_euca_nightlies_centos6.dita
+++ b/content/en_us/ig/installing_euca_nightlies_centos6.dita
@@ -25,7 +25,7 @@
     		<step>
     			<cmd>On all servers, run the following commands:</cmd>
     			<info>
-    				<codeblock>yum --nogpgcheck install -y http://downloads.eucalyptus.com/
+    				<codeblock>yum --nogpgcheck install http://downloads.eucalyptus.com/
 software/eucalyptus/nightly/3.2/centos/6/x86_64/eucalyptus-release-3.2.0-0.1.el6.noarch.rpm</codeblock>
     			</info>
     		</step>
@@ -33,21 +33,21 @@ software/eucalyptus/nightly/3.2/centos/6/x86_64/eucalyptus-release-3.2.0-0.1.el6
                         <cmd>On all systems that will run either Eucalyptus or Euca2ools, run the following
                                 commands:</cmd>
                         <info>
-                                <codeblock>yum --nogpgcheck install -y http://downloads.eucalyptus.com/software/
+                                <codeblock>yum --nogpgcheck install http://downloads.eucalyptus.com/software/
 euca2ools/nightly/2.1/centos/6/x86_64/euca2ools-release-2.1.noarch.rpm</codeblock>
                         </info>
                 </step>
                 <step>
                         <cmd>Install the ELRepo repository on the machine that will run Walrus:</cmd>
                         <info>  
-                                <codeblock>yum --nogpgcheck install -y http://downloads.eucalyptus.com/
+                                <codeblock>yum --nogpgcheck install http://downloads.eucalyptus.com/
 software/eucalyptus/nightly/3.2/centos/6/x86_64/elrepo-release-6.noarch.rpm</codeblock>
                         </info> 
                 </step>
                 <step>
                         <cmd> Configure the EPEL package repository:</cmd>
                         <info>
-                                <codeblock>yum --nogpgcheck install -y http://downloads.eucalyptus.com/software/eucalyptus/nightly/3.2/centos/6/x86_64/epel-release-6.noarch.rpm</codeblock>
+                                <codeblock>yum --nogpgcheck install http://downloads.eucalyptus.com/software/eucalyptus/nightly/3.2/centos/6/x86_64/epel-release-6.noarch.rpm</codeblock>
                         </info>
                 </step>
         	<step>

--- a/content/en_us/ig/installing_euca_nightlies_rhel6.dita
+++ b/content/en_us/ig/installing_euca_nightlies_rhel6.dita
@@ -25,7 +25,7 @@
         	<step>
         	<cmd>Run the following command on all servers:</cmd>
         	<info>
-        		<codeblock>yum --nogpg install -y http://downloads.eucalyptus.com/software/eucalyptus/
+        		<codeblock>yum --nogpg install http://downloads.eucalyptus.com/software/eucalyptus/
 nightly/3.2/rhel/6/x86_64/eucalyptus-release-3.2.0-0.1.el6.noarch.rpm</codeblock>
         	</info>
         	</step>
@@ -33,7 +33,7 @@ nightly/3.2/rhel/6/x86_64/eucalyptus-release-3.2.0-0.1.el6.noarch.rpm</codeblock
                         <cmd>On all systems that will run either Eucalyptus or Euca2ools, run the following
                                 command:</cmd>
                         <info>
-                                <codeblock>yum install -y http://downloads.eucalyptus.com/software/
+                                <codeblock>yum install http://downloads.eucalyptus.com/software/
 nightly/euca2ools/2.1/rhel/6/x86_64/euca2ools-release-2.1.noarch.rpm</codeblock>
                         </info>
                 </step>

--- a/content/en_us/ig/upgrade_packages.dita
+++ b/content/en_us/ig/upgrade_packages.dita
@@ -27,14 +27,14 @@
      <note type="tip">For larger deployments, use a script to upgrade the component host machines.
       For example:
       <codeblock>for host in 28 29 32 33 35 39 40; do echo 192.168.51.$host; ssh
-192.168.51.$host 'yum update -y $( rpm -qa | grep euca )' ; done</codeblock>
+192.168.51.$host 'yum update $( rpm -qa | grep euca )' ; done</codeblock>
      </note>
     </stepresult>
    </step>
    <step>
     <cmd>On the CLC, run the following command:</cmd>
     <info>
-     <codeblock>yum groupinstall -y eucalyptus-cloud-controller</codeblock>
+     <codeblock>yum groupinstall eucalyptus-cloud-controller</codeblock>
     </info>
    </step>
    <step props="subscribe">


### PR DESCRIPTION
Putting yum's -y option in documentation encourages muscle memory that
can destroy a system when one makes a mistake.  This commit removes that
option from the eucalyptus documentation; RHEL users are very familiar
with how to say yes/no when using yum.
