### PR TITLE
fixed type in euare-accountuploadpolicy

### DIFF
--- a/content/en_us/cli/euare-accountuploadpolicy.dita
+++ b/content/en_us/cli/euare-accountuploadpolicy.dita
@@ -34,7 +34,7 @@
 						</row>
 						<row>
 							<entry><codeph>-p, --policy-name <i>policy_name</i></codeph></entry>
-							<entry>Name of the policy document to delete</entry>
+							<entry>Name of the policy document to upload</entry>
 							<entry align="center">Yes</entry>
 						</row>
 						<row>


### PR DESCRIPTION
In euare-accountuploadpolicy, it says -p for policy document to delete, where it should be to upload.

-p, --policy-name policy_name | Name of the policy document to delete
