### PR TITLE
Update versioning in upgrade section based on supported upgrade paths

### DIFF
--- a/content/en_us/ig/upgrade.dita
+++ b/content/en_us/ig/upgrade.dita
@@ -16,9 +16,8 @@
 	<conbody>
 		
 			<p>You can upgrade to Eucalyptus <ph conref="../shared/conrefs.dita#prod/version"/>
-				from either <ph conref="../shared/conrefs.dita#prod/upgrade_option1"/> or <ph
-					conref="../shared/conrefs.dita#prod/prev_version"/>. To upgrade from any other version of
-				Eucalyptus, you should first upgrade to either of those versions. Follow the
+				from <ph conref="../shared/conrefs.dita#prod/prev_version"/>. To upgrade from any other version of
+                Eucalyptus, you should first upgrade to <ph conref="../shared/conrefs.dita#prod/prev_version"/>. Follow the
 				directions in the previous Installation Guide, and then upgrade to <ph conref="../shared/conrefs.dita#prod/version"/>
 				using the directions in this section.</p>
 			

--- a/content/en_us/ig/upgrade_prep.dita
+++ b/content/en_us/ig/upgrade_prep.dita
@@ -6,14 +6,14 @@
 	<shortdesc/>
 	<taskbody>
 		<context>
-			
+
 			<p>Complete the following steps to upgrade to Eucalyptus <ph
 					conref="../shared/conrefs.dita#prod/version"/> on CentOS 6
 				or RHEL 6.</p>
 			<note type="note">
 				<p>You should already have the repositories installed for
 					euca2ools, EPEL, and ELRepo from your <ph
-						conref="../shared/conrefs.dita#prod/upgrade_option1"/>
+						conref="../shared/conrefs.dita#prod/prev_version"/>
 					installation. If you do not have these installed, refer to
 					the installation instructions to find out how to add these
 					to your machines.</p>

--- a/content/en_us/ig/upgrade_start.dita
+++ b/content/en_us/ig/upgrade_start.dita
@@ -20,14 +20,14 @@
 					<codeblock>service eucalyptus-cloud start</codeblock>
 				</info>
 				<stepresult>
-					<p>If you are upgrading from <ph conref="../shared/conrefs.dita#prod/upgrade_option1"/> you
+					<p>If you are upgrading from <ph conref="../shared/conrefs.dita#prod/prev_version"/> you
 						will see that the process starts the database upgrade. Eucalyptus
 						returns output similar to the following example.</p>
-					<codeblock>Starting Eucalyptus services: Attempting database upgrade from 3.2.2
+                    <codeblock>Starting Eucalyptus services: Attempting database upgrade from <ph conref="../shared/conrefs.dita#prod/prev_version"/>
 at /var/lib/eucalyptus/upgrade/eucalyptus.backup.1326904600...
 #                           UPGRADE INFORMATION
 #================================================================================
-# Old Version:              <ph conref="../shared/conrefs.dita#prod/upgrade_option1"/>
+# Old Version:              <ph conref="../shared/conrefs.dita#prod/prev_version"/>
 # New Version:              <ph conref="../shared/conrefs.dita#prod/version"/>
 # Upgrade keys:             false              using:
 # Upgrade configuration:    false              using:
@@ -56,14 +56,14 @@ done.</codeblock>
 					<codeblock conref="../shared/reuse.dita#reuse/euca_start"/>
 				</info>
 				<stepresult>
-					<p>If you are upgrading from <ph conref="../shared/conrefs.dita#prod/upgrade_option1"/> you
+					<p>If you are upgrading from <ph conref="../shared/conrefs.dita#prod/prev_version"/> you
 						will see that Eucalyptus returns output similar to the following
 						example.</p>
-					<codeblock>Starting Eucalyptus services: Attempting database upgrade from 3.2.2
+                    <codeblock>Starting Eucalyptus services: Attempting database upgrade from <ph conref="../shared/conrefs.dita#prod/prev_version"/>
 at /var/lib/eucalyptus/upgrade/eucalyptus.backup.1326905005...
 #                           UPGRADE INFORMATION
 #================================================================================
-# Old Version:              <ph conref="../shared/conrefs.dita#prod/upgrade_option1"/>
+# Old Version:              <ph conref="../shared/conrefs.dita#prod/prev_version"/>
 # New Version:              <ph conref="../shared/conrefs.dita#prod/version"/>
 # Upgrade keys:             false              using:
 # Upgrade configuration:    false              using:
@@ -107,14 +107,14 @@ done.</codeblock>
 					<codeblock conref="../shared/reuse.dita#reuse/euca_start"/>
 				</info>
 				<stepresult>
-					<p>If you are upgrading from <ph conref="../shared/conrefs.dita#prod/upgrade_option1"/> you
+					<p>If you are upgrading from <ph conref="../shared/conrefs.dita#prod/prev_version"/> you
 						will see that Eucalyptus returns output similar to the following
 						example></p>
-					<codeblock>Starting Eucalyptus services: Attempting database upgrade from 3.2.2
+                    <codeblock>Starting Eucalyptus services: Attempting database upgrade from <ph conref="../shared/conrefs.dita#prod/upgrade_options1"/>
 at /var/lib/eucalyptus/upgrade/eucalyptus.backup.1326905005...
 #                           UPGRADE INFORMATION
 #================================================================================
-# Old Version:              <ph conref="../shared/conrefs.dita#prod/upgrade_option1"/>
+# Old Version:              <ph conref="../shared/conrefs.dita#prod/prev_version"/>
 # New Version:              <ph conref="../shared/conrefs.dita#prod/version"/>
 # Upgrade keys:             false              using:
 # Upgrade configuration:    false              using:


### PR DESCRIPTION
Since we are supporting upgrade from 3.3.2 to 3.4.0 only, I've updated the upgrade section to reflect that.
