### PR TITLE
Added a small caveat to avoid recursive DNS lookups.

### DIFF
--- a/content/en_us/euca2ools-guide/euca-install-image.dita
+++ b/content/en_us/euca2ools-guide/euca-install-image.dita
@@ -73,7 +73,7 @@
 							<entry align="center">No</entry>
 						</row>
 						<row>
-							<entry><codeph>--platform-windows</codeph></entry>
+							<entry><codeph>--platform windows</codeph></entry>
 							<entry>Indicates the new image is based on Windows.</entry>
 							<entry align="center">No</entry>
 						</row>

--- a/content/en_us/security-guide/roles_priv.dita
+++ b/content/en_us/security-guide/roles_priv.dita
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
 <concept id="roles_priv">
-    <title>Priviledged Roles</title>
+    <title>Privileged Roles</title>
 	<shortdesc>The <codeph>eucalyptus</codeph> account is a super privileged account in Eucalyptus. It has access to all cloud’s resources, cloud setup and management. The users within these account do not obey IAM policies and compromise of their credentials can result in a complete cloud compromise that is not easy to contain. We recommend to limit usage of this account and associated users’ credentials as much as possible.</shortdesc>
     <conbody>
     	

--- a/content/en_us/shared/nw_edge_shared.dita
+++ b/content/en_us/shared/nw_edge_shared.dita
@@ -193,7 +193,7 @@ VNET_DHCPDAEMON="/usr/sbin/dhcpd"</codeblock>
                 "10.111.101.94",
                 "10.111.101.95"
             ]
-        },
+        }
     ]
 }</codeblock>
 				<p>For a multi-cluster deployment, add an additional

--- a/content/en_us/shared/setting_up_dns.dita
+++ b/content/en_us/shared/setting_up_dns.dita
@@ -27,6 +27,14 @@
 				port 53. To use the Eucalyptus DNS service, you must disable these services.</p>
 		</context>
 
+		<info>
+			<note>
+				<p>Be sure that when you set up DNS that you set the <codeph>nameserver</codeph> in <codeph>/etc/resolv.conf</codeph> on the CLC
+				to something <i>other</i> than the IP of the CLC, to avoid the possibility of the DNS service recursivly querying itself.
+				</p>
+			</note>
+		</info>
+
 	</taskbody>
 	<task id="setting_up_dns_subd">
 		<title>Configure the Domain and Subdomain</title>

--- a/content/en_us/shared/setting_up_dns_ha.dita
+++ b/content/en_us/shared/setting_up_dns_ha.dita
@@ -29,7 +29,15 @@
 				To use the Eucalyptus DNS service, you must disable
 				these services.</p>
 		</context>
-		
+
+		<info>
+			<note>
+				<p>Be sure that when you set up DNS that you set the <codeph>nameserver</codeph> in <codeph>/etc/resolv.conf</codeph> on the CLC
+				to something <i>other</i> than the IP of the CLC, to avoid the possibility of the DNS service recursivly querying itself.
+				</p>
+			</note>
+		</info>
+
 	</taskbody>
 	<task id="setting_up_dns_subd_ha">
 		<title>Configure the Domain and Subdomain</title>


### PR DESCRIPTION
Since the CLC can be configured to provide DNS services, it depends on
it’s /etc/resolv.conf not being misconfigured to reference itself. See
EUCA-7963 for more info.

Also corrected typo on "Privileged Roles" page.