### PR TITLE
Update MEM related documentation

### DIFF
--- a/content/en_us/install-guide/install_midokura.dita
+++ b/content/en_us/install-guide/install_midokura.dita
@@ -13,7 +13,7 @@
                 <ph conref="../shared/conrefs.dita#prod/product"/>
                 will be deployed into your environment.</li>
             <li>See the <xref
-                    href="http://docs.midokura.com/docs/latest/quick-start-guide/rhel-7_kilo-rdo/content/_midonet_installation.html"
+                    href="http://docs.midokura.com/docs/v1.9/en/quick-start-guide/rhel-7_kilo-rdo/content/_midonet_installation.html"
                     format="html" scope="external">MidoNet Installation Guide</xref> to become
                 familiar with the general Midokura Enterprise MidoNet installation procedure and concepts.</li>
         </ul>

--- a/content/en_us/install-guide/install_midokura_installation.dita
+++ b/content/en_us/install-guide/install_midokura_installation.dita
@@ -332,7 +332,7 @@ systemctl enable midolman.service</codeblock>
                                 recommended.</note>
                         </p>
                         <p>See the <xref
-                                href="http://docs.midokura.com/docs/v1.9/en/quick-start-guide/rhel-7_juno-osp/content/_midolman_installation.html"
+                                href="http://docs.midokura.com/docs/v1.9/en/quick-start-guide/rhel-7_kilo-rdo/content/_midolman_installation.html"
                                 format="html" scope="external">Midolman Installation
                                 documentation</xref> for more information.</p>
                     </info>

--- a/content/en_us/install-guide/install_midokura_prereqs.dita
+++ b/content/en_us/install-guide/install_midokura_prereqs.dita
@@ -10,8 +10,8 @@
   <section>
    <title>Repository Access</title>
     <p>In order to use MidoNet with <ph conref="../shared/conrefs.dita#prod/product"/> you need
-        access to the Midokura repositories. You can sign up here: <xref
-          href="https://support.midokura.com/access/unauthenticated" format="html" scope="external"
+        access credentials to the Midokura repositories. Contact Midokura's sales department for sign up information: <xref
+          href="mailto:sales@midokura.com" format="email" scope="external"
         />.</p>
    <p>Create <codeph>/etc/yum.repos.d/midokura.repo</codeph> on all machines that will run MidoNet
         components including ZooKeeper. For example:</p>
@@ -27,7 +27,7 @@ enabled=1</codeblock>
    <p>ZooKeeper is where MidoNet stores most of its running state. This service needs to be up and
         running before any other installation takes place. </p>
    <note>For advanced ZooKeeper installation (clustered for reliability), please see the <xref
-          href="http://docs.midokura.com/docs/latest/quick-start-guide/rhel-7_kilo-rdo/content/_nsdb_nodes.html"
+          href="http://docs.midokura.com/docs/v1.9/en/quick-start-guide/rhel-7_kilo-rdo/content/_nsdb_nodes.html"
           format="html" scope="external">MidoNet NSDB Installation Guide</xref>. </note>
    <p>For a simple single-server installation, install the ZooKeeper package on any server that is
         IP accessible from all Midolman agents (for example: on the Cloud Controller server itself),
@@ -48,7 +48,7 @@ systemctl enable zookeeper.service</codeblock>
      href="http://docs.datastax.com/en/cassandra/2.2/cassandra/initialize/initSingleDS.html"
      format="html" scope="external">configuration</xref>.</p>
    <note>For advanced MidoNet-specific installation of Cassandra, please refer to the <xref
-          href="http://docs.midokura.com/docs/latest/quick-start-guide/rhel-7_kilo-rdo/content/_nsdb_nodes.html"
+          href="http://docs.midokura.com/docs/v1.9/en/quick-start-guide/rhel-7_kilo-rdo/content/_nsdb_nodes.html"
           format="html" scope="external">MidoNet NSDB Installation Guide</xref>. </note>
   </section>
  </conbody>


### PR DESCRIPTION
This patch set updates the following aspects of the Midokura
Enterprise MidoNet (MEM) related documentation:

1) Point to correct version of external docs

Eucalyptus currently only supports MEM v1.9.

Change the external links to Midokura's documentation to point to
v1.9 instead of the latest version (which is v5.2 at the time of
writing).

2) Point to same set of external docs

Most of the external links point to Midokura's "RHEL 7 / Kilo (RDO)"
set of the documentation, just one link pointed to "RHEL 7 / Juno
(OSP)" instead. Unify this.

3) Update repository access information

To access the Midokura repository, access credentials are necessary.

Signing up for those should not be done via support.midokura.com,
which is an internal portal for technical support of existing
customers.

Add an email address to contact the Midokura sales department
instead.

Signed-off-by: Jan Hilberath <jan@midokura.com>